### PR TITLE
Suport darwin-arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,23 @@ on:
   push:
     tags:
       - "v*"
-permissions:
-  contents: write
 
 jobs:
-  release:
+  goreleaser:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cli/gh-extension-precompile@v1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,19 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+archives:
+  - name_template: "{{ .Os }}-{{ .Arch }}"
+    format: binary
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  skip: true
+release:
+  draft: true


### PR DESCRIPTION
Resolves #2 

Goreleaser does not automatically generate release notes, so you will need to register your release in draft form and click the "Auto generate release-notes" button manually before publishing.

<img width="933" alt="image" src="https://user-images.githubusercontent.com/5178598/151959086-eb4ee852-e3b0-4ec5-bf6f-2f264575d54a.png">

https://github.com/seachicken/gh-s/releases/tag/v1.0.0

ref: https://goreleaser.com/ci/actions/#usage