### PR TITLE
new flag to limit results

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,24 +52,25 @@ gh s [search] [flag]
 ```
 takes one of the following arguments or flags
 
-| flags        | description                                      | multiple   | example
-|:------------ |:------------------------------------------------ |:---------- |:--------
-| -E, --empty  | do not prompt for name, search by flags only     | no         | gh s -E -l go -l rust
-| -l, --lang   | narrow down the search to a specific language    | yes (OR)   | gh s prompt -l go -l lua
-| -d, --desc   | search for keyword in the repository description | no         | gh s neovim -d plugin
-| -u, --user   | restrict the search to a specific user           | no         | gh s lsp -u neovim
-| -t, --topic  | narrow down the search to specific topics        | yes (AND)  | gh s lsp -t plugin -t neovim
-| -c, --colour | change colour of the prompt                      | no         | gh s nvim -c magenta
-| -h, --help   | show the help page                               | no         | gh s -h
-| -V, --version| print the current version                        | no         | gh s -V
+| flags         | description                                      | multiple  | example                      |
+| :------------ | :----------------------------------------------- | :-------- | :--------------------------- |
+| -E, --empty   | do not prompt for name, search by flags only     | no        | gh s -E -l go -l rust        |
+| -l, --lang    | narrow down the search to a specific language    | yes (OR)  | gh s prompt -l go -l lua     |
+| -d, --desc    | search for keyword in the repository description | no        | gh s neovim -d plugin        |
+| -u, --user    | restrict the search to a specific user           | no        | gh s lsp -u neovim           |
+| -t, --topic   | narrow down the search to specific topics        | yes (AND) | gh s lsp -t plugin -t neovim |
+| -c, --colour  | change colour of the prompt                      | no        | gh s nvim -c magenta         |
+| -L, --limit   | limit the number of results (default 20)         | no        | gh s nvim -L 3               |
+| -h, --help    | show the help page                               | no        | gh s -h                      |
+| -V, --version | print the current version                        | no        | gh s -V                      |
 
 The prompt accepts the following navigation commands:
 
-| key           | description
-|:------------- |:-----------------------------------
-| arrow keys    | browse results list
-| `/`           | toggle search in results list
-| `enter (<CR>)`| print selected repository URL to `stdout`
+| key            | description                               |
+| :------------- | :---------------------------------------- |
+| arrow keys     | browse results list                       |
+| `/`            | toggle search in results list             |
+| `enter (<CR>)` | print selected repository URL to `stdout` |
 
 ### Search by topic or language only
 `gh-s` allows to skip prompting for a repository name by passing the `-E` flag; this in turn implies that the query searches against all possible GitHub repositories, which may result in longer response times. Notice furthermore that `-E` must always be accompanied by at least another non-empty flag. Use with care, however it does allow for some interesting statistics or general curiosity: check the [Wiki](https://github.com/gennaro-tedesco/gh-s/wiki/Common-queries)!

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,7 @@ func init() {
 	rootCmd.Flags().StringP("user", "u", "", "search repository by user")
 	rootCmd.Flags().StringSliceVarP(&topics, "topic", "t", []string{}, "search repository by topic")
 	rootCmd.Flags().StringP("colour", "c", "cyan", "colour of selection prompt")
-	rootCmd.Flags().IntP("limit", "L", 20, "limit the number of results")
+	rootCmd.Flags().IntP("limit", "L", 20, "limit the number of results (default 20)")
 	rootCmd.Flags().BoolP("empty", "E", false, "allow for empty name search")
 	rootCmd.Flags().BoolP("version", "V", false, "print current version")
 	rootCmd.SetHelpTemplate(getRootHelp())
@@ -128,7 +128,7 @@ Flags:
                 multiple topics can be specified:
                 -t go -t gh-extension
   -c, --colour  change prompt colour
-  -L, --limit   Limit results
+  -L, --limit   limit the number of results (default 20)
   -V, --version print current version
   -h, --help    show this help page
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ var rootCmd = &cobra.Command{
 		user, _ := cmd.Flags().GetString("user")
 		topicList, _ := cmd.Flags().GetStringSlice("topic")
 		colour, _ := cmd.Flags().GetString("colour")
+		limit, _ := cmd.Flags().GetInt("limit")
 
 		searchString := func() string {
 			if empty, _ := (cmd.Flags().GetBool("empty")); empty {
@@ -45,7 +46,7 @@ var rootCmd = &cobra.Command{
 			fmt.Println("\033[31m ✘\033[0m No results found")
 			os.Exit(1)
 		}
-		PromptList := getSelectionPrompt(repos, colour)
+		PromptList := getSelectionPrompt(repos, colour, limit)
 
 		idx, _, err := PromptList.Run()
 		if err != nil {
@@ -68,6 +69,7 @@ func init() {
 	rootCmd.Flags().StringP("user", "u", "", "search repository by user")
 	rootCmd.Flags().StringSliceVarP(&topics, "topic", "t", []string{}, "search repository by topic")
 	rootCmd.Flags().StringP("colour", "c", "cyan", "colour of selection prompt")
+	rootCmd.Flags().IntP("limit", "L", 20, "limit the number of results")
 	rootCmd.Flags().BoolP("empty", "E", false, "allow for empty name search")
 	rootCmd.Flags().BoolP("version", "V", false, "print current version")
 	rootCmd.SetHelpTemplate(getRootHelp())
@@ -126,6 +128,7 @@ Flags:
                 multiple topics can be specified:
                 -t go -t gh-extension
   -c, --colour  change prompt colour
+  -L, --limit   Limit results
   -V, --version print current version
   -h, --help    show this help page
 

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -85,14 +85,14 @@ func getTemplate(colour string) *promptui.SelectTemplates {
 
 }
 
-func getSelectionPrompt(repos []repoInfo, colour string) *promptui.Select {
+func getSelectionPrompt(repos []repoInfo, colour string, limit int) *promptui.Select {
 	return &promptui.Select{
 		Stdout:    os.Stderr,
 		Stdin:     os.Stdin,
 		Label:     "repository list",
 		Items:     repos,
 		Templates: getTemplate(colour),
-		Size:      20,
+		Size:      limit,
 		Searcher: func(input string, idx int) bool {
 			repo := repos[idx]
 			title := strings.ToLower(repo.Name)


### PR DESCRIPTION
## Description
This PR aims to introduce a new flag (-L/ --limit) into this repo that allows the number of results to be limited.
The name of the flag was derived from the [gh](https://github.com/cli/cli) tool, see image below for more clarity.

<img src="https://ttm.sh/w99.58.jpg" width="600">

Fix #17

## code quality
The code was checked with [.pre-commit-config.yaml](../blob/master/.pre-commit-config.yaml) and lintered with [golangci-lint](https://github.com/golangci/golangci-lint). See log outpul below for more clarity, the raised issue from the linter I have left in there for now, I can remove it if you like.

```zsh
❯ git add . && git commit -m "new flag to limit results"
go fmt...................................................................Passed
go-unit-tests............................................................Passed
go-build.................................................................Passed
go-mod-tidy..............................................................Passed
[limit a0d20e9] new flag to limit results
 3 files changed, 22 insertions(+), 18 deletions(-)
❯ golangci-lint run
cmd/root.go:10:5: `cfgFile` is unused (deadcode)
var cfgFile string
    ^
```

### note
This is only the second time I have edited code in `Go`. Feel free to propose changes or commit the patch with your own changes.
